### PR TITLE
bagfix/modal's-buttons

### DIFF
--- a/src/sass/components/_modal.scss
+++ b/src/sass/components/_modal.scss
@@ -244,7 +244,7 @@
   &:hover,
   &:focus {
     cursor: pointer;
-    border: none;
+    border: 1px solid transparent;
     background-color: var(--accent-color);
     color: var(--font-color-light);
   }


### PR DESCRIPTION
Добавила прозрачный бордер на кнопки модалки, чтобы они "не прыгали" при ховере.